### PR TITLE
Add CSS style sheet with @font-face declaration

### DIFF
--- a/webfonts/Chunkfive.css
+++ b/webfonts/Chunkfive.css
@@ -1,0 +1,18 @@
+/*
+  Chunk
+  https://www.theleagueofmoveabletype.com/chunk
+
+  Copyright (c) 2009, Meredith Mandel <meredith@meredithmandel.com>,
+  with Reserved Font Name: "Chunk".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Chunk';
+  src: url('Chunkfive-webfont.eot?#iefix') format('embedded-opentype'),
+       url('Chunkfive-webfont.woff') format('woff'),
+       url('Chunkfive-webfont.ttf')  format('truetype'),
+       url('Chunkfive-webfont.svg#webfont90E2uSjN') format('svg');
+  font-weight: 800; /* Ultra Bold */
+}

--- a/webfonts/Chunkfive.css
+++ b/webfonts/Chunkfive.css
@@ -10,6 +10,7 @@
 */
 @font-face {
   font-family: 'Chunk';
+  src: url('Chunkfive-webfont.eot'),
   src: url('Chunkfive-webfont.eot?#iefix') format('embedded-opentype'),
        url('Chunkfive-webfont.woff') format('woff'),
        url('Chunkfive-webfont.ttf')  format('truetype'),

--- a/webfonts/Chunkfive.css
+++ b/webfonts/Chunkfive.css
@@ -10,7 +10,7 @@
 */
 @font-face {
   font-family: 'Chunk';
-  src: url('Chunkfive-webfont.eot'),
+  src: url('Chunkfive-webfont.eot');
   src: url('Chunkfive-webfont.eot?#iefix') format('embedded-opentype'),
        url('Chunkfive-webfont.woff') format('woff'),
        url('Chunkfive-webfont.ttf')  format('truetype'),


### PR DESCRIPTION
The format used for the @font-face declaration is the
"Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
